### PR TITLE
adding config for WB's JBrowse 2 dev server

### DIFF
--- a/jbrowse_webserver.conf
+++ b/jbrowse_webserver.conf
@@ -28,6 +28,20 @@ server {
 
 server {
    listen         80;
+   server_name jbrowse2_wb_dev.alliancegenome.org;
+
+   gzip on;
+
+   location / {
+      proxy_pass_request_headers      on;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_pass http://agr.jbrowse.jb2_wb_dev.server:80;
+   }
+}
+
+server {
+   listen         80;
    server_name jbrowse_wb_prod.alliancegenome.org;
 
    gzip on;


### PR DESCRIPTION
presumably also needs a DNS entry that points requests for jbrowse2_wb_dev.alliancegenome.org at this nginx server. 